### PR TITLE
Fixed python json.load(file) issue

### DIFF
--- a/elasticsearch/mapping/index_settings.json
+++ b/elasticsearch/mapping/index_settings.json
@@ -1,4 +1,4 @@
-﻿{
+{
    "settings": {
       "analysis": {
          "filter": {


### PR DESCRIPTION
In the end, the thing which fixed it was to copy into pycharm and paste back into the mapping file. 
This seemed to remove whatever character was blocking json.load() and worked in my test. 
Let me know if you get the same result.